### PR TITLE
Remove unnecessary 'b' dependency

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -7,15 +7,15 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(['exports', 'b'], factory);
+        define(['exports'], factory);
     } else if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
         // CommonJS
-        factory(exports, require('b'));
+        factory(exports);
     } else {
         // Browser globals
-        factory((root.commonJsStrict = {}), root.b);
+        factory((root.commonJsStrict = {}));
     }
-}(this, function (exports, b) {
+}(this, function (exports) {
 
     if (typeof Promise !== 'function') {
         /*!


### PR DESCRIPTION
Currently used UMD pattern is very weird at best. This is only a quick fix to be able to use Croppie e.g. with Webpack (which was throwing the `Cannot resolve module 'b'` error).