### PR TITLE
Support of image format and image quality for canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Get the resulting crop of the image.
 * `type: 'html'` returns html with the positioned correctly and overflow hidden.
 * `size: 'viewport'` returns the cropped image sized the same as the viewport.
 * `size: 'original'`  returns the cropped image at the image's original dimensions.
-* * size is only applicable on canvas results
+* `format: 'jpg|png|webp'` indicating the image format. Default is `jpg`.
+* `quality: '1'` number between 0 and 1 indicating image quality. Default is `1`.
+* * size, format and quality are only applicable on canvas results.
+* * quality is only applicable with formats `jpg` and `webp`.
 
 **refresh()** *void*
 

--- a/croppie.js
+++ b/croppie.js
@@ -787,7 +787,7 @@
             type = (typeof (opts) === 'string' ? opts : opts.type),
             size = opts.size || 'viewport',
             format = opts.format || 'jpg',
-            quality = opts.quality || '1',
+            quality = opts.quality || 1,
             vpRect,
             prom;
 

--- a/croppie.js
+++ b/croppie.js
@@ -162,7 +162,7 @@
 
         ctx.drawImage(img, left, top, width, height, 0, 0, outWidth, outHeight);
 
-        return canvas.toDataURL();
+        return canvas.toDataURL(data.format, data.quality);
     }
 
     /* Utilities */
@@ -783,9 +783,11 @@
     function _result(options) {
         var self = this,
             data = _get.call(self),
-            opts = options || { type: 'canvas', size: 'viewport' },
+            opts = options || { type: 'canvas', size: 'viewport', format: 'jpg', quality: 1 },
             type = (typeof (opts) === 'string' ? opts : opts.type),
             size = opts.size || 'viewport',
+            format = opts.format || 'jpg',
+            quality = opts.quality || '1',
             vpRect,
             prom;
 
@@ -793,6 +795,11 @@
             vpRect = self.elements.viewport.getBoundingClientRect();
             data.outputWidth = vpRect.width;
             data.outputHeight = vpRect.height;
+        }
+
+        if (['jpg', 'jpeg', 'webp'].indexOf(format) > -1) {
+            data.format = (format === 'webp' ? 'image/webp' : 'image/jpeg');
+            data.quality = quality;
         }
 
         data.circle = self.options.viewport.type === 'circle';


### PR DESCRIPTION
I've added the support of image format, allowing the developer to get an image in `jpg` and `webp`, in addition of the original `png` format that was set by default.

They can also decide the image quality if the image is not in `png`.