### PR TITLE
Zoom not working if the zoomer is not displayed

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -871,7 +871,7 @@
         this.options = deepExtend(deepExtend({}, Croppie.defaults), opts);
 
         // backwards compatibility
-        if (typeof(opts.showZoomer) !== 'undefined') {
+        if (typeof(opts.showZoomer) !== 'undefined' && opts.showZoomer !== false) {
             this.options.enableZoom = this.options.showZoomer = opts.showZoomer;
         }
 

--- a/croppie.js
+++ b/croppie.js
@@ -871,7 +871,9 @@
         this.options = deepExtend(deepExtend({}, Croppie.defaults), opts);
 
         // backwards compatibility
-        this.options.enableZoom = this.options.showZoomer;
+        if (typeof(opts.showZoomer) !== 'undefined') {
+            this.options.enableZoom = this.options.showZoomer = opts.showZoomer;
+        }
 
         _create.call(this);
     }


### PR DESCRIPTION
I fixed a bug with the zoom not working on Mac and iOS devices using the "wheel/pinch", when the zoomer is not displayed. It might have fixed Windows computer as well.