### PR TITLE
Move dependency on mocha to "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "A simple javascript image cropper",
   "main": "croppie.js",
-  "dependencies": {
+  "devDependencies": {
     "mocha": "2.4.5"
   },
   "scripts": {


### PR DESCRIPTION
Package "mocha" is not used outside of the development workflow in this project. It doesn't make sense for it to be included as direct package "dependency" as when this package it used in production it will now pull "mocha" (which in turn has a number of dependencies).

Moving "mocha" out to "devDependencies" will still let you run `npm test`, but thanks to this change apps that depend on "croppie" won't be required to pull in "mocha".