### PR TITLE
Mobile - pinch-to-zoom center point gets stuck after using slider

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -834,6 +834,7 @@
                 _transferImageToCanvas.call(self);
             }
             _updatePropertiesFromImage.call(self);
+            _updateCenterPoint.call(self);
             _triggerUpdate.call(self);
             if (cb) {
                 cb();

--- a/croppie.js
+++ b/croppie.js
@@ -338,10 +338,7 @@
     function _initializeZoom() {
         var self = this,
             wrap = self.elements.zoomerWrap = document.createElement('div'),
-            zoomer = self.elements.zoomer = document.createElement('input'),
-            origin,
-            viewportRect,
-            transform;
+            zoomer = self.elements.zoomer = document.createElement('input');
 
         addClass(wrap, 'cr-slider-wrap');
         addClass(zoomer, 'cr-slider');
@@ -354,19 +351,13 @@
         wrap.appendChild(zoomer);
 
         self._currentZoom = 1;
-        function start() {
-            _updateCenterPoint.call(self);
-            origin = new TransformOrigin(self.elements.preview);
-            viewportRect = self.elements.viewport.getBoundingClientRect();
-            transform = Transform.parse(self.elements.preview);
-        }
 
         function change() {
             _onZoom.call(self, {
                 value: parseFloat(zoomer.value),
-                origin: origin || new TransformOrigin(self.elements.preview),
-                viewportRect: viewportRect || self.elements.viewport.getBoundingClientRect(),
-                transform: transform || Transform.parse(self.elements.preview)
+                origin: new TransformOrigin(self.elements.preview),
+                viewportRect: self.elements.viewport.getBoundingClientRect(),
+                transform: Transform.parse(self.elements.preview)
             });
         }
 
@@ -386,13 +377,9 @@
             targetZoom = self._currentZoom + delta;
 
             ev.preventDefault();
-            start();
             _setZoomerVal.call(self, targetZoom);
             change();
         }
-
-        self.elements.zoomer.addEventListener('mousedown', start);
-        self.elements.zoomer.addEventListener('touchstart', start);
 
         self.elements.zoomer.addEventListener('input', change);// this is being fired twice on keypress
         self.elements.zoomer.addEventListener('change', change);


### PR DESCRIPTION
When using Croppie on a mobile, pinch-to-zoom works as expected, until you use the range slider. The slider's mousedown/touchstart events set the center point for zooming, which is then used as the center point for pinch-to-zoom until the slider is clicked again.

To reproduce:
 - Open Croppie on mobile, and test pinch-to-zoom. The zoom center point works as expected.
 - Drag the zoom slider.
 - Move the picture around, and then test pinch-to-zoom again. Now the center point is reset to the center point last used by the zoom slider.

This PR simply removes the `start` function (which sets local variables `origin`, `viewportRect`, `transform`, which cause the issue). The `change` function still works without these variables being set.