### PR TITLE
Add support for custom orientation

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -741,7 +741,7 @@
         css(self.elements.preview, CSS_TRANSFORM, transform.toString());
     }
 
-    function _transferImageToCanvas() {
+    function _transferImageToCanvas(customOrientation) {
         var self = this,
             canvas = self.elements.canvas,
             img = self.elements.img,
@@ -753,6 +753,9 @@
 
         getExifOrientation(img, function (orientation) {
             rotateCanvas(canvas, ctx, img, parseInt(orientation));
+            if (customOrientation) {
+                rotateCanvas(canvas, ctx, img, customOrientation);
+            }
         });
     }
 
@@ -841,7 +844,7 @@
         prom.then(function () {
             if (self.options.useCanvas) {
                 self.elements.img.exifdata = null;
-                _transferImageToCanvas.call(self);
+                _transferImageToCanvas.call(self, options.orientation);
             }
             _updatePropertiesFromImage.call(self);
             _updateCenterPoint.call(self);

--- a/croppie.js
+++ b/croppie.js
@@ -274,7 +274,7 @@
             customViewportClass = self.options.viewport.type ? 'cr-vp-' + self.options.viewport.type : null,
             boundary, img, viewport, overlay, canvas;
 
-        self.options.useCanvas = self.options.exif && window.EXIF;
+        self.options.useCanvas = self.options.customOrientation || self.options.exif && window.EXIF;
         // Properties on class
         self.data = {};
         self.elements = {};
@@ -745,6 +745,7 @@
         var self = this,
             canvas = self.elements.canvas,
             img = self.elements.img,
+            customOrientationEnabled = self.options.customOrientation,
             ctx = canvas.getContext('2d');
 
         ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -753,7 +754,7 @@
 
         getExifOrientation(img, function (orientation) {
             rotateCanvas(canvas, ctx, img, parseInt(orientation));
-            if (customOrientation) {
+            if (customOrientationEnabled && customOrientation) {
                 rotateCanvas(canvas, ctx, img, customOrientation);
             }
         });

--- a/croppie.js
+++ b/croppie.js
@@ -745,19 +745,24 @@
         var self = this,
             canvas = self.elements.canvas,
             img = self.elements.img,
-            customOrientationEnabled = self.options.customOrientation,
+            exif = self.options.exif,
+            customOrientation = self.options.customOrientation && customOrientation,
             ctx = canvas.getContext('2d');
 
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         canvas.width = img.width;
         canvas.height = img.height;
 
-        getExifOrientation(img, function (orientation) {
-            rotateCanvas(canvas, ctx, img, parseInt(orientation));
-            if (customOrientationEnabled && customOrientation) {
-                rotateCanvas(canvas, ctx, img, customOrientation);
-            }
-        });
+        if (exif) {
+            getExifOrientation(img, function (orientation) {
+                rotateCanvas(canvas, ctx, img, parseInt(orientation));
+                if (customOrientation) {
+                    rotateCanvas(canvas, ctx, img, customOrientation);
+                }
+            });
+        } else if (customOrientation) {
+            rotateCanvas(canvas, ctx, img, customOrientation);
+        }
     }
 
     function _getHtmlResult(data) {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -82,9 +82,13 @@ var Demo = (function() {
 		var vanilla = new Croppie(document.getElementById('vanilla-demo'), {
 			viewport: { width: 100, height: 100 },
 			boundary: { width: 300, height: 300 },
-			showZoomer: false
+			showZoomer: false,
+            customOrientation: true
 		});
-		vanilla.bind('demo/demo-2.jpg');
+		vanilla.bind({
+            url: 'demo/demo-2.jpg',
+            orientation: 4
+        });
 		document.querySelector('.vanilla-result').addEventListener('click', function (ev) {
 			vanilla.result('canvas').then(function (src) {
 				popupResult({

--- a/index.html
+++ b/index.html
@@ -177,6 +177,12 @@ $('#item').croppie(method, args);</code></pre>
                             <br /><br />
                             <span class="default">Valid type values:</span><code class="language-javascript">'square' 'circle'</code>
                         </li>
+                        <li>
+                            <strong class="focus">customOrientation</strong><em>boolean</em>
+                            <p>Enable or disable support for specifying a custom orientation when binding images (See <code class="language-javascript">bind</code> method)</p>
+                            <span class="default">Default</span>
+                            <code class="language-javascript">false</code>
+                        </li>
                     </ul>
                 </section>
                 <section>
@@ -187,13 +193,28 @@ $('#item').croppie(method, args);</code></pre>
                             <p>Get the crop points, and the zoom of the image.</p>
                         </li>
                         <li>
-                            <strong class="focus">bind({ url, points })</strong><em>Promise</em>
+                            <strong class="focus">bind({ url, points, orientation })</strong><em>Promise</em>
                             <p>Bind an image the croppie.  Returns a promise to be resolved when the image has been loaded and the croppie has been initialized.</p>
                             <span class="default">Parameters</span>
                             <br />
                             <ul class="parameter-list">
                                 <li><code class="language-javascript">url</code> URL to image</li>
                                 <li><code class="language-javascript">points</code> Array of points that translate into <code class="language-javascript">[topLeftX, topLeftY, bottomRightX, bottomRightY]</code></li>
+                                <li><code class="language-javascript">orientation</code> Custom orientation, applied after exif orientation (if enabled). Only works with <code class="language-javascript">customOrientation</code> option enabled (see 'Options').
+                                    <br />
+                                    Valid options are:
+                                    <ul>
+                                        <li><code class="language-javascript">1</code> unchanged</li>
+                                        <li><code class="language-javascript">2</code> flipped horizontally</li>
+                                        <li><code class="language-javascript">3</code> rotated 180 degrees</li>
+                                        <li><code class="language-javascript">4</code> flipped vertically</li>
+                                        <li><code class="language-javascript">5</code> flipped horizontally, then rotated left by 90 degrees</li>
+                                        <li><code class="language-javascript">6</code> rotated left by 90 degrees</li>
+                                        <li><code class="language-javascript">7</code> flipped horizontally, then rotated right by 90 degrees</li>
+                                        <li><code class="language-javascript">8</code> rotated right by 90 degrees</li>
+                                    </pre>
+                                    </ul>
+                                </li>
                             </ul>
                         </li>
                         <li>

--- a/index.html
+++ b/index.html
@@ -308,9 +308,13 @@ var el = document.getElementById('vanilla-demo');
 var vanilla = new Croppie(el, {
     viewport: { width: 100, height: 100 },
     boundary: { width: 300, height: 300 },
-    showZoomer: false
+    showZoomer: false,
+    customOrientation: true
 });
-vanilla.bind('demo/demo-2.jpg');
+vanilla.bind({
+    url: 'demo/demo-2.jpg',
+    orientation: 4
+});
 //on button click
 vanilla.result('canvas');</code></pre>
                                 <div class="actions">


### PR DESCRIPTION
Adds `orientation` option to `bind` method which allows a custom orientation change on top of the exif one. Since this requires the use of the canvas element for the preview this currently has to be enabled explicitly via the `customOrientation` option during initialization. A couple of considerations:

- It would be nice to have support for this without having to 'opt in' during initialization but that would require either adjusting the `useCanvas` option dynamically during each bind or just using the canvas in general. I'm assuming the image is used where possible for performance reasons?

- There is the question whether the custom orientation should be applied **after** the exif orientation or **instead**. I've opted for after for now but I'd be fine with either.

- Why this PR? Because I need a widget that allows rotating/flipping images in addition to cropping. I could do the transformations using a separate canvas and then rebind the new image but since Croppie basically already supports this it is easier to just expose it via the api. I wouldn't suggest adding UI elements for this though, those can easily be added 'from the outside' if needed. Adding a couple of convenience methods like `rotateLeft`, `rotateRight`, `flipHorizontally` etc. might be useful though.