### PR TITLE
Add option to override circle result

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -213,9 +213,9 @@
             cb(0);
         }
 
-        EXIF.getData(img, function () { 
+        EXIF.getData(img, function () {
             var orientation = EXIF.getTag(this, 'Orientation');
-            cb(orientation);            
+            cb(orientation);
         });
     }
 
@@ -426,7 +426,7 @@
             }
 
             targetZoom = self._currentZoom + delta;
-            
+
             ev.preventDefault();
             _setZoomerVal.call(self, targetZoom);
             change();
@@ -942,8 +942,8 @@
     }
 
     var RESULT_DEFAULTS = {
-            type: 'canvas', 
-            format: 'png', 
+            type: 'canvas',
+            format: 'png',
             quality: 1
         },
         RESULT_FORMATS = ['jpeg', 'webp', 'png'];
@@ -956,6 +956,7 @@
             size = opts.size,
             format = opts.format,
             quality = opts.quality,
+            circle = typeof opts.circle === 'boolean' ? opts.circle : (self.options.viewport.type === 'circle'),
             vpRect = self.elements.viewport.getBoundingClientRect(),
             ratio = vpRect.width / vpRect.height,
             prom;
@@ -981,7 +982,7 @@
             data.quality = quality;
         }
 
-        data.circle = self.options.viewport.type === 'circle';
+        data.circle = circle;
         data.url = self.data.url;
 
         prom = new Promise(function (resolve, reject) {
@@ -1143,6 +1144,6 @@
     exports.Croppie = window.Croppie = Croppie;
 
     if (typeof module === 'object' && !!module.exports) {
-        module.exports = Croppie;    
+        module.exports = Croppie;
     }
 }));


### PR DESCRIPTION
I have added an option to the result function so I can override the shape that's exported. For me, the use case is that I want the user to crop their profile photo so it displays well in a circle, but I want to store it on the server as a square.

The options object now accepts the "circle" parameter, which can be true or false. If it's not passed through, or not a boolean, the exported shape is as before. I was unsure how best to implement this - if you have another idea, I am happy to change the PR.

The documentation doesn't appear to be part of the repo, so I was unable to update it.

Also, as with my previous PR, my IDE has trimmed the whitespace - there are actually only two lines changed. You can add ?w=1 to the URL to ignore the whitespace if you want.