### PR TITLE
Only set crossorigin image prop when using canvas

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -135,7 +135,7 @@
     }
 
     /* Utilities */
-    function loadImage(src, imageEl) {
+    function loadImage(src, imageEl, useCanvas) {
         var img = imageEl || new Image(),
             prom;
 
@@ -146,7 +146,7 @@
             });
         } else {
             prom = new Promise(function (resolve, reject) {
-                if (src.substring(0,4).toLowerCase() === 'http') {
+                if (useCanvas && src.substring(0,4).toLowerCase() === 'http') {
                     img.setAttribute('crossOrigin', 'anonymous');
                 }
                 img.onload = function () {
@@ -1012,7 +1012,7 @@
             return parseFloat(p);
         });
         self.data.boundZoom = zoom;
-        var prom = loadImage(url, self.elements.img);
+        var prom = loadImage(url, self.elements.img, self.options.useCanvas);
         prom.then(function () {
             if (self.options.useCanvas) {
                 self.elements.img.exifdata = null;


### PR DESCRIPTION
The crossorigin image property is mainly useful when the image is loaded into a canvas element, to prevent the canvas from becoming tainted and thus impossible to extract data from.

Setting the crossorigin property on an image will trigger CORS policies when loading images, and will prevent images from being loaded if they're hosted on a cross origin without appropriate CORS headers set in the response. Being able to crop externally hosted images is still useful even if the external host does not set CORS headers, with the only limitation of not being able to rotate the image.