### PR TITLE
New options: zoomerMatchBoundary & mouseWheelZoomRelative

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -420,6 +420,10 @@
         self.element.appendChild(wrap);
         wrap.appendChild(zoomer);
 
+        if (self.options.zoomerMatchBoundary) {
+            css(wrap, 'width', self.options.boundary.width+'px');
+        }
+
         self._currentZoom = 1;
 
         function change() {
@@ -1237,6 +1241,7 @@
         enableExif: false,
         enforceBoundary: true,
         enableOrientation: false,
+        zoomerMatchBoundary: false,
         update: function () { }
     };
 

--- a/croppie.js
+++ b/croppie.js
@@ -448,7 +448,7 @@
                 delta = 0;
             }
 
-            targetZoom = self._currentZoom + delta;
+            targetZoom = self._currentZoom + (self.options.mouseWheelZoomRelative ? delta * self._currentZoom : delta);
 
             ev.preventDefault();
             _setZoomerVal.call(self, targetZoom);
@@ -1242,6 +1242,7 @@
         enforceBoundary: true,
         enableOrientation: false,
         zoomerMatchBoundary: false,
+        mouseWheelZoomRelative: false,
         update: function () { }
     };
 


### PR DESCRIPTION
New option added called zoomerMatchBoundary. When set to true, the width
of the slider wrapper element (.cr-slider-wrap) is set to the given
boundary width to match the slider in size to the boundary.

Default: false

-----

New option added called mouseWheelZoomRelative. When set to true, the
mousewheel delta used to increment the zoom level is multiplied by the
current zoom level. This makes the zoom jumps by mousewheel relative to
the current zoom level, avoiding big jumps at low zoom levels for
instance.

Default: false