### PR TITLE
correct imgData values

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -815,7 +815,10 @@
         cssReset['opacity'] = 1;
         css(img, cssReset);
 
-        imgData = img.getBoundingClientRect();
+        imgData = {
+            width   : img.naturalWidth,
+            height  : img.naturalHeight
+        };
         vpData = self.elements.viewport.getBoundingClientRect();
         boundaryData = self.elements.boundary.getBoundingClientRect();
         self._originalImageWidth = imgData.width;


### PR DESCRIPTION
The imgData values should be based on the actual image width and height, not from getBoundingClientRect().