### PR TITLE
Responsive boundaries

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -336,8 +336,8 @@
 
         addClass(boundary, 'cr-boundary');
         css(boundary, {
-            width: self.options.boundary.width + 'px',
-            height: self.options.boundary.height + 'px'
+            width: (self.options.boundary.width + (isNaN(self.options.boundary.width) ? '' : 'px')),
+            height: (self.options.boundary.height + (isNaN(self.options.boundary.height) ? '' : 'px'))
         });
 
         addClass(viewport, 'cr-viewport');
@@ -530,8 +530,8 @@
             scale = self._currentZoom,
             vpWidth = viewport.width,
             vpHeight = viewport.height,
-            centerFromBoundaryX = self.options.boundary.width / 2,
-            centerFromBoundaryY = self.options.boundary.height / 2,
+            centerFromBoundaryX = self.elements.boundary.clientWidth / 2,
+            centerFromBoundaryY = self.elements.boundary.clientHeight / 2,
             imgRect = self.elements.preview.getBoundingClientRect(),
             curImgWidth = imgRect.width,
             curImgHeight = imgRect.height,


### PR DESCRIPTION
I patched Croppie to not only accept a fixed-size (in pixels) boundary, but basically any CSS value (like `50%`). This allows for image containers that are dynamically adjusted when the screen is resized.

After doing that, I discovered a bug: when you zoom into one corner of the image, and then zoom out, the boundaries were not enforced correctly. The calculation in `_getVirtualBoundaries` relied on the boundary dimensions being numbers. I fixed this by using clientWidth/Height on the actual element instead.

Note: Resizing the window can still cause the viewport to select regions outside of the original image.

The change in the boundary configuration (public API) is kinda problematic, but I still want to share this thing. I think this is some progress for #214 and maybe #168.