### PR TITLE
Slider style ugly on MS Edge

### DIFF
--- a/croppie.css
+++ b/croppie.css
@@ -139,6 +139,7 @@
     width: 16px;
     border-radius: 50%;
     background: #ddd;
+    margin-top:1px;
 }
 .cr-slider:focus::-ms-fill-lower {
     background: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
Issue with slider on Windows Mobile 10 in MS Edge. 
See the screenshot below.
Not reproducible on desktop IE with any phone emulation.
Need a real phone to see this.