### PR TITLE
Detect Prototype.js and use CustomEvent if detected

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -789,8 +789,8 @@
         }
 
         self.options.update.call(self, data);
-        if (self.$) {
-            self.$(self.element).trigger('update', data)
+        if (self.$ && typeof Prototype == 'undefined') {
+            self.$(self.element).trigger('update', data); 
         }
         else {
             var ev;


### PR DESCRIPTION
This change simply checks for Prototype.js and, if found, uses the logic that creates a CustomEvent instead of using jQuery's event logic.

This addresses the issue that I reported in #244 