### PR TITLE
Slider fixed width in IE (Update croppie.css)

### DIFF
--- a/croppie.css
+++ b/croppie.css
@@ -138,7 +138,7 @@ background: #ccc;
 }
 
 .cr-slider::-ms-track {
-    width: 300px;
+    width: 100%;
     height: 5px;
     background: transparent;
 /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */


### PR DESCRIPTION
Prevents input control from extending beyond the slider track in Internet Explorer.
Width currently set to 300px width

Without fix:
![image](https://cloud.githubusercontent.com/assets/3158625/23363833/789542c6-fcf4-11e6-9547-9fca1bcbcba2.png)

With fix:
![image](https://cloud.githubusercontent.com/assets/3158625/23363917/da498586-fcf4-11e6-99a2-33226c8ae4d4.png)
