### PR TITLE
Makes the zoom slider easier to click

### DIFF
--- a/croppie.css
+++ b/croppie.css
@@ -85,6 +85,9 @@
     width: 300px;
 /*required for proper track sizing in FF*/
     max-width: 100%;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    background-color: transparent;
 }
 
 .cr-slider::-webkit-slider-runnable-track {


### PR DESCRIPTION
Adds a few pixels of transparent padding around the zoom slider so that the
user has more than 3px of vertical space that they can click on in order
to zoom in a specific amount. I found that limiting the slider input element to 3px in height made it more challenging to click on the slider to adjust the zoom than necessary.

Note that this refers to clicking on a point on the slider and having the zoom adjusted to that point rather than dragging the slider to that point.