### PR TITLE
Fix default value of Croppie size parameter

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1175,7 +1175,7 @@
             data = _get.call(self),
             opts = deepExtend(RESULT_DEFAULTS, deepExtend({}, options)),
             resultType = (typeof (options) === 'string' ? options : (opts.type || 'base64')),
-            size = opts.size,
+            size = opts.size || 'viewport',
             format = opts.format,
             quality = opts.quality,
             backgroundColor = opts.backgroundColor,


### PR DESCRIPTION
According to this [documentation ](https://foliotek.github.io/Croppie/) the size parameter's default value should be `viewport`. But there is no assignment as a default value. Because of this if there is no given size parameter, it behaves like it is "original".