### PR TITLE
Support resize of viewport

### DIFF
--- a/croppie.css
+++ b/croppie.css
@@ -22,7 +22,8 @@
     height: 100%;
 }
 
-.croppie-container .cr-viewport {
+.croppie-container .cr-viewport,
+.croppie-container .cr-resizer {
     position: absolute;
     border: 2px solid #fff;
     margin: auto;
@@ -32,6 +33,54 @@
     left: 0;
     box-shadow: 0 0 2000px 2000px rgba(0, 0, 0, 0.5);
     z-index: 0;
+}
+
+.croppie-container .cr-resizer {
+  z-index: 2;
+  box-shadow: none;
+  pointer-events: none;
+}
+
+.croppie-container .cr-resizer-vertical,
+.croppie-container .cr-resizer-horisontal {
+  position: absolute;
+  pointer-events: all;
+}
+
+.croppie-container .cr-resizer-vertical::after,
+.croppie-container .cr-resizer-horisontal::after {
+    display: block;
+    position: absolute;
+    box-sizing: border-box;
+    border: 1px solid black;
+    background: #fff;
+    width: 10px;
+    height: 10px;
+    content: '';
+}
+
+.croppie-container .cr-resizer-vertical {
+  bottom: -5px;
+  cursor: row-resize;
+  width: 100%;
+  height: 10px;
+}
+
+.croppie-container .cr-resizer-vertical::after {
+    left: 50%;
+    margin-left: -5px;
+}
+
+.croppie-container .cr-resizer-horisontal {
+  right: -5px;
+  cursor: col-resize;
+  width: 10px;
+  height: 100%;
+}
+
+.croppie-container .cr-resizer-horisontal::after {
+    top: 50%;
+    margin-top: -5px;
 }
 
 .croppie-container .cr-original-image {

--- a/croppie.js
+++ b/croppie.js
@@ -378,12 +378,12 @@
             _initializeZoom.call(self);
         }
 
-        if (this.options.enableResize) {
-            _initializeResize.call(this);
-        }
+        // if (self.options.enableOrientation) {
+        //     _initRotationControls.call(self);
+        // }
 
-        if (self.options.enableOrientation) {
-            _initRotationControls.call(self);
+        if (self.options.enableResize) {
+            _initializeResize.call(self);
         }
     }
 
@@ -535,26 +535,6 @@
                     });
                 }
             }
-
-            /*
-            if (ev.type == 'touchmove') {
-                if (ev.touches.length > 1) {
-                    var touch1 = ev.touches[0];
-                    var touch2 = ev.touches[1];
-                    var dist = Math.sqrt((touch1.pageX - touch2.pageX) * (touch1.pageX - touch2.pageX) + (touch1.pageY - touch2.pageY) * (touch1.pageY - touch2.pageY));
-
-                    if (!originalDistance) {
-                        originalDistance = dist / self._currentZoom;
-                    }
-
-                    var scale = dist / originalDistance;
-
-                    _setZoomerVal.call(self, scale);
-                    dispatchChange(self.elements.zoomer);
-                    return;
-                }
-            }
-            */
 
             _updateOverlay.call(self);
             _updateZoomLimits.call(self);

--- a/croppie.js
+++ b/croppie.js
@@ -460,15 +460,14 @@
                 return;
             }
 
-            var viewportRect = self.elements.viewport.getBoundingClientRect();
             var overlayRect = self.elements.overlay.getBoundingClientRect();
 
             isDragging = true;
             originalX = ev.pageX;
             originalY = ev.pageY;
             direction = ev.currentTarget.className.indexOf('vertical') !== -1 ? 'v' : 'h';
-            maxWidth = self.options.viewport.width + (overlayRect.right - viewportRect.right);
-            maxHeight = self.options.viewport.height + (overlayRect.bottom - viewportRect.bottom);
+            maxWidth = overlayRect.width;
+            maxHeight = overlayRect.height;
 
             if (ev.touches) {
                 var touches = ev.touches[0];

--- a/croppie.js
+++ b/croppie.js
@@ -1039,8 +1039,8 @@
             minH;
 
         if (self.options.enforceBoundary) {
-            minW = vpData.width / (imgData.width / scale);
-            minH = vpData.height / (imgData.height / scale);
+            minW = vpData.width / (initial ? imgData.width : imgData.width / scale);
+            minH = vpData.height / (initial ? imgData.height : imgData.height / scale);
             minZoom = Math.max(minW, minH);
         }
 

--- a/croppie.js
+++ b/croppie.js
@@ -378,7 +378,7 @@
             _initializeZoom.call(self);
         }
 
-        if (this.options.enableViewportResize) {
+        if (this.options.enableResize) {
             _initializeResize.call(this);
         }
 
@@ -428,6 +428,7 @@
         var direction;
         var originalX;
         var originalY;
+        var minSize = 50;
         var maxWidth;
         var maxHeight;
         var vr;
@@ -500,7 +501,7 @@
             if (direction == 'v') {
                 var newHeight = self.options.viewport.height + deltaY;
 
-                if (newHeight <= maxHeight) {
+                if (newHeight >= minSize && newHeight <= maxHeight) {
                     css(wrap, {
                         height: newHeight + 'px'
                     });
@@ -519,7 +520,7 @@
             else {
                 var newWidth = self.options.viewport.width + deltaX;
 
-                if (newWidth <= maxWidth) {
+                if (newWidth >= minSize && newWidth <= maxWidth) {
                     css(wrap, {
                         width: newWidth + 'px'
                     });
@@ -1526,7 +1527,7 @@
         customClass: '',
         showZoomer: true,
         enableZoom: true,
-        enableViewportResize: false,
+        enableResize: false,
         mouseWheelZoom: true,
         enableExif: false,
         enforceBoundary: true,

--- a/croppie.js
+++ b/croppie.js
@@ -557,6 +557,8 @@
             */
 
             _updateOverlay.call(self);
+            _updateCenterPoint.call(self);
+            _triggerUpdate.call(self);
             originalY = pageY;
             originalX = pageX;
         }
@@ -869,8 +871,6 @@
             window.addEventListener('touchend', mouseUp);
             document.body.style[CSS_USERSELECT] = 'none';
             vpRect = self.elements.viewport.getBoundingClientRect();
-
-            console.log(originalX, originalY, vpRect);
         }
 
         function mouseMove(ev) {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -134,6 +134,34 @@ var Demo = (function() {
 		});
 	}
 
+    function demoResizer() {
+		var vEl = document.getElementById('resizer-demo'),
+			resize = new Croppie(vEl, {
+			viewport: { width: 100, height: 100 },
+			boundary: { width: 300, height: 300 },
+			showZoomer: false,
+            enableResize: true,
+            enableOrientation: true
+		});
+		resize.bind({
+            url: 'demo/demo-2.jpg',
+            zoom: 0
+        });
+        vEl.addEventListener('update', function (ev) {
+        	console.log('resize update', ev);
+        });
+		document.querySelector('.resizer-result').addEventListener('click', function (ev) {
+			resize.result({
+				type: 'blob'
+			}).then(function (blob) {
+				window.open(window.URL.createObjectURL(blob));
+				popupResult({
+					src: src
+				});
+			});
+		});
+	}
+
 	function demoUpload() {
 		var $uploadCrop;
 
@@ -218,6 +246,7 @@ var Demo = (function() {
 		demoMain();
 		demoBasic();	
 		demoVanilla();	
+		demoResizer();
 		demoUpload();
 		demoHidden();
 	}

--- a/index.html
+++ b/index.html
@@ -358,6 +358,37 @@ vanilla.result('blob').then(function(blob) {
                         </div>
                     </div>
                 </div>
+                <div class="demo-wrap">
+                    <div class="container">
+                        <div class="grid">
+                            <div class="col-1-2">
+                                <strong>Resizer Example</strong>
+                                <pre class="language-javascript"><code class="language-javascript">
+var el = document.getElementById('resizer-demo');
+var resize = new Croppie(el, {
+    viewport: { width: 100, height: 100 },
+    boundary: { width: 300, height: 300 },
+    showZoomer: false,
+    enableResize: true,
+    enableOrientation: true
+});
+resize.bind({
+    url: 'demo/demo-2.jpg',
+});
+//on button click
+resize.result('blob').then(function(blob) {
+    // do something with cropped blob
+});</code></pre>
+                                <div class="actions">
+                                    <button class="resizer-result">Result</button>
+                                </div>
+                            </div>
+                            <div class="col-1-2">
+                                <div id="resizer-demo"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div class="demo-wrap upload-demo">
                     <div class="container">
                     <div class="grid">


### PR DESCRIPTION
This adds a brand new feature supporting resize of the viewport. It's an option that needs to be explicitly turned on, and one can choose whether height and/or width should be possible to change. We've used this feature ourself in production for a while, mostly locking resize to height, and it works well as far as we've seen. Although support on touch devices have not been tested.

Since an image is usually in the document flow, we feel it makes most sense to only allow dragging to resize on the bottom and right side of the image. This adds handles, similar to crop+resize in Photoshop and other image editors, at the bottom and right of the viewport. Clicking and dragging on the handles will update the viewport size dynamically. Size is limited to a minimum of 50px, and a maximum of the current height of the actual image.

I've added a demo of it on the official demo page. Since tests does not seem to be used much/up to date, I haven't added any new tests for this.

Any input is very welcome, and I hope we can make this fit in the main version of Croppie making it easier for us to keep our use up to date.