### PR TITLE
Fix zoom problems with enforceBoundary turned off

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1155,8 +1155,9 @@
 
         if (data.backgroundColor) {
             ctx.fillStyle = data.backgroundColor;
-            ctx.fillRect(0, 0, outWidth, outHeight);
+            ctx.fillRect(0, 0, canvasWidth, canvasHeight);
         }
+
 
         // start fixing data to send to draw image for enforceBoundary: false
         if (!self.options.enforceBoundary) {
@@ -1177,6 +1178,10 @@
                 outHeight = height;
             }
         }
+        else{
+           width=Math.min(width, self._originalImageWidth);
+           height=Math.min(height, self._originalImageHeight)
+        }
 
         if (outputRatio !== 1) {
             startX *= outputRatio;
@@ -1184,8 +1189,7 @@
             outWidth *= outputRatio;
             outHeight *= outputRatio;
         }
-
-        ctx.drawImage(this.elements.preview, left, top, Math.min(width, self._originalImageWidth), Math.min(height, self._originalImageHeight), startX, startY, outWidth, outHeight);
+        ctx.drawImage(this.elements.preview, left, top, width, height, startX, startY, outWidth, outHeight);
         if (circle) {
             ctx.fillStyle = '#fff';
             ctx.globalCompositeOperation = 'destination-in';


### PR DESCRIPTION
I some situations the result image is scaled out of ratio!
I tagged  down the problem to:
Math.min(width, self._originalImageWidth)
I don't know why its needed ... but if i removed it its working ok!