### PR TITLE
Added touchStart events for enableResize

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -570,10 +570,12 @@
 
         if (vr) {
             vr.addEventListener('mousedown', mouseDown);
+            vr.addEventListener('touchstart', mouseDown);
         }
 
         if (hr) {
             hr.addEventListener('mousedown', mouseDown);
+            hr.addEventListener('touchstart', mouseDown);
         }
 
         this.elements.boundary.appendChild(wrap);


### PR DESCRIPTION
Problem: iOS does not fire mousedown event when you touch the screen in most situations, and code relies on aforementioned event as it's sole means of operation.

Implemented Solution: Add two lines of code initiating operation using touchstart event as well as mousedown event.