### PR TITLE
Remove unnecessary export

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1589,8 +1589,4 @@
     });
 
     exports.Croppie = window.Croppie = Croppie;
-
-    if (typeof module === 'object' && !!module.exports) {
-        module.exports = Croppie;
-    }
 }));


### PR DESCRIPTION
I'm not sure why we need that bit of code. It creates inconsistency of how we export the module. Since calling `exports.Croppie = ...` is setting the `Croppie` property of the `exports` object. But calling `module.exports = ...` is **overwriting** the whole `export` object.

By the way, `exports` and `module.exports` is *kind of* the same thing. But if you set the value of `module.exports`, it takes priority. Read [this](https://blog.tableflip.io/the-difference-between-module-exports-and-exports/) for more information.