### PR TITLE
Fix UMD, export the whole Croppie class

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -13,9 +13,9 @@
         factory(exports);
     } else {
         // Browser globals
-        factory((root.commonJsStrict = {}));
+        factory((root.Croppie = {}));
     }
-}(this, function (exports) {
+}(typeof self !== 'undefined' ? self : this, function (exports) {
 
     /* Polyfills */
     if (typeof Promise !== 'function') {
@@ -1571,5 +1571,5 @@
         }
     });
 
-    exports.Croppie = window.Croppie = Croppie;
+    exports = Croppie;
 }));


### PR DESCRIPTION
This is my proposal to #470.

Using a template from https://github.com/umdjs/umd/blob/master/templates/commonjsStrict.js.

# Browser globals

```html
<script src="croppie.js"></script>
```
```javascript
var croppie = new Croppie(...);
```

# CommonJS

```javascript
const Croppie = require('croppie');
const croppie = new Croppie(...);
```

# ES Modules

```javascript
import Croppie from 'croppie'
const croppie = new Croppie(...);
```

CC: @thedustinsmith, @oystehei please take a look!

Closes #470