### PR TITLE
Fix typo that makes it unusable in strict mode

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1159,7 +1159,7 @@
             canvasWidth = data.outputWidth || width,
             canvasHeight = data.outputHeight || height,
             customDimensions = (data.outputWidth && data.outputHeight),
-            outputWidthRatio = 1;
+            outputWidthRatio = 1,
             outputHeightRatio = 1;
 
         canvas.width = canvasWidth;


### PR DESCRIPTION
This typo makes it unusable in strict mode because it doesn't allow to create global variables in this way, and i believe you didn't want it too https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Converting_mistakes_into_errors