### PR TITLE
Don't silently discard image loading errors

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -178,7 +178,7 @@
     function loadImage(src, doExif) {
         var img = new Image();
         img.style.opacity = 0;
-        return new Promise(function (resolve) {
+        return new Promise(function (resolve, reject) {
             function _resolve() {
                 img.style.opacity = 1;
                 setTimeout(function () {
@@ -200,6 +200,12 @@
                 else {
                     _resolve();
                 }
+            };
+            img.onerror = function (ev) {
+                img.style.opacity = 1;
+                setTimeout(function () {
+                    reject(ev);
+                }, 1);
             };
             img.src = src;
         });
@@ -1296,8 +1302,6 @@
             _updatePropertiesFromImage.call(self);
             _triggerUpdate.call(self);
             cb && cb();
-        }).catch(function (err) {
-            console.error("Croppie:" + err);
         });
     }
 


### PR DESCRIPTION
The `bind` method returns a promise which mainly awaits loading the image URL. If an error happened within the image loader, then the `bind` method would simply log it to the console and the caller's promise handling would continue as if everything was fine. In addition, network issues or otherwise errors in the browser's loading of the image was not caught and propagated back up to the `bind` method.

This implements a simple `onerror` handler for loading the image which rejects the loading promise. The `catch` handler in the `bind` method which swallowed any rejections have also been removed, which enables the caller to handle this properly on their side.