### PR TITLE
Error handling for corrupted images

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -178,7 +178,7 @@
     function loadImage(src, doExif) {
         var img = new Image();
         img.style.opacity = 0;
-        return new Promise(function (resolve) {
+        return new Promise(function (resolve, reject) {
             function _resolve() {
                 img.style.opacity = 1;
                 setTimeout(function () {
@@ -201,6 +201,9 @@
                     _resolve();
                 }
             };
+            img.onerror = function () {
+                reject('Unable to load image');
+            }
             img.src = src;
         });
     }
@@ -1295,9 +1298,9 @@
             }
             _updatePropertiesFromImage.call(self);
             _triggerUpdate.call(self);
-            cb && cb();
+            cb && cb(true);
         }).catch(function (err) {
-            console.error("Croppie:" + err);
+            cb && cb(false, err);
         });
     }
 


### PR DESCRIPTION
Currently, I'm using bind with a callback to hide a loading mask when Croppie is ready for user interaction. However, callback won't be called when a user selects a corrupted image, there are no possibilities to handle such a case.

I've added reject for promise in case of an error occurs during the image loading. Also, I've added parameters to the callback, so now we can use it like that:
```javascript
function (success, errorText) {
    if (success) {
        //do something, e.g. hide loading mask
    } else {
        //show error, e.g. console.log(errorText)
    }
}
```