### PR TITLE
Fix Global Definition

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -13,7 +13,7 @@
         factory(exports);
     } else {
         // Browser globals
-        factory((root.Croppie = {}));
+        root.Croppie = factory();
     }
 }(typeof self !== 'undefined' ? self : this, function (exports) {
 
@@ -1583,4 +1583,5 @@
     });
 
     exports = Croppie;
+    return Croppie;
 }));


### PR DESCRIPTION
Fixes demo page and instances where you're just including the script in your page and calling `new Croppie()` without imports, defines, requires, or anything.