### PR TITLE
Add the option to set a minimum zoom ratio.

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1061,7 +1061,7 @@
 
     function _updateZoomLimits (initial) {
         var self = this,
-            minZoom = 0,
+            minZoom = Math.max(self.options.minZoom, 0) || 0,
             maxZoom = self.options.maxZoom || 1.5,
             initialZoom,
             defaultInitialZoom,


### PR DESCRIPTION
Added the ability to set a minimum zoom ratio (minZoom property).
If set to a negative number, the default 0 will be used.

enforceBoundary needs to be set to 'true', in order for the zoom to reach the minimum.