### PR TITLE
Allow the minZoom level to bet set from the options.

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1061,7 +1061,7 @@
 
     function _updateZoomLimits (initial) {
         var self = this,
-            minZoom = 0,
+            minZoom = self.options.minZoom || 0,
             maxZoom = self.options.maxZoom || 1.5,
             initialZoom,
             defaultInitialZoom,


### PR DESCRIPTION
This allows the `minZoom` coefficient to be passed in thru the options just like `maxZoom`. 
