### PR TITLE
Remove crossOrigin attribute changing

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -186,11 +186,6 @@
                 }, 1);
             }
 
-            img.removeAttribute('crossOrigin');
-            if (src.match(/^https?:\/\/|^\/\//)) {
-                img.setAttribute('crossOrigin', 'anonymous');
-            }
-
             img.onload = function () {
                 if (doExif) {
                     EXIF.getData(img, function () {


### PR DESCRIPTION
Hi,

Changing `crossOrigin` attribute here will prevent loading image from trusted source (having capability of reading credentials from current domain).

For example: I am at website https://example.com. I want to crop the image that is located at https://img.example.com/some.jpg - which have ability of reading cookie from `*.example.com` to authenticate me. But the code of Croppie set the crossOrigin to anonymous (for any http/https images), so it fails loading the image.

I suggest letting it be default behavior of browser.

Cheers!