### PR TITLE
Fixes#463: match cropped image size to viewport size

### DIFF
--- a/croppie.css
+++ b/croppie.css
@@ -32,6 +32,7 @@
     right: 0;
     left: 0;
     box-shadow: 0 0 2000px 2000px rgba(0, 0, 0, 0.5);
+    box-sizing: border-box;
     z-index: 0;
 }
 


### PR DESCRIPTION
Cropped image had 4px added to height and width from the 2px border so added box-sizing: border-box to viewport.