### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "sweetalert": "~1.1.3",
+    "sweetalert2": "~7.33.1",
     "jquery": "~2.1.4",
     "exif-js": "~2.1.1"
   }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -19,10 +19,7 @@ var Demo = (function() {
 			html = '<img src="' + result.src + '" />';
 		}
 		swal({
-			title: '',
-			html: true,
-			text: html,
-			allowOutsideClick: true
+			html: html
 		});
 		setTimeout(function(){
 			$('.sweet-alert').css('margin', function() {
@@ -172,7 +169,7 @@ var Demo = (function() {
 		function readFile(input) {
  			if (input.files && input.files[0]) {
 	            var reader = new FileReader();
-	            
+
 	            reader.onload = function (e) {
 					$('.upload-demo').addClass('ready');
 	            	$uploadCrop.croppie('bind', {
@@ -180,9 +177,9 @@ var Demo = (function() {
 	            	}).then(function(){
 	            		console.log('jQuery bind complete');
 	            	});
-	            	
+
 	            }
-	            
+
 	            reader.readAsDataURL(input.files[0]);
 	        }
 	        else {
@@ -248,8 +245,8 @@ var Demo = (function() {
 	function init() {
 		bindNavigation();
 		demoMain();
-		demoBasic();	
-		demoVanilla();	
+		demoBasic();
+		demoVanilla();
 		demoResizer();
 		demoUpload();
 		demoHidden();
@@ -275,22 +272,22 @@ var Demo = (function() {
   ];
   var length = methods.length;
   var console = (window.console = window.console || {});
- 
+
   while (length--) {
     method = methods[length];
- 
+
     // Only stub undefined methods.
     if (!console[method]) {
         console[method] = noop;
     }
   }
- 
- 
+
+
   if (Function.prototype.bind) {
     window.log = Function.prototype.bind.call(console.log, console);
   }
   else {
-    window.log = function() { 
+    window.log = function() {
       Function.prototype.apply.call(console.log, console, arguments);
     };
   }

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html lang ="en">
     <head>
         <meta charset="UTF-8" >
@@ -15,7 +15,6 @@
 
         <link href='//fonts.googleapis.com/css?family=Open+Sans:300,400,400italic,600,700' rel='stylesheet' type='text/css'>
         <link rel="Stylesheet" type="text/css" href="demo/prism.css" />
-        <link rel="Stylesheet" type="text/css" href="bower_components/sweetalert/dist/sweetalert.css" />
         <link rel="Stylesheet" type="text/css" href="croppie.css" />
         <link rel="Stylesheet" type="text/css" href="demo/demo.css" />
         <link rel="icon" href="//foliotek.github.io/favico-64.png" />
@@ -74,7 +73,7 @@ $('.my-image').croppie();
                 <pre class="language-javascript" style="width: 225px;"><code class="language-javascript">bower install croppie</code></pre>
                 <p><strong>Download:</strong></p>
                 <p><a href="https://github.com/Foliotek/Croppie/releases">Source</a></p>
-                
+
                 <hr />
                 <p><strong>Then add the following elements to your page:</strong></p>
                 <pre class="language-html"><code class="language-html">&lt;link rel="stylesheet" href="croppie.css" /&gt;
@@ -86,7 +85,7 @@ $('.my-image').croppie();
             <div class="section-header"><h2>Usage</h2></div>
             <div class="container">
                 <p>You can initialize Croppie with the following code:</p>
-                
+
               <pre class="language-javascript"><code class="language-javascript">var c = new Croppie(document.getElementById('item'), opts);
 // call a method
 c.method(args);</code></pre>
@@ -157,7 +156,7 @@ $('#item').croppie(method, args);</code></pre>
                             <strong class="focus">viewport</strong><em>object</em>
                             <p>The inner container of the coppie.  The visible part of the image</p>
                             <span class="default">Default</span>
-                            <code class="language-javascript">{ 
+                            <code class="language-javascript">{
                                 width: 100,
                                 height: 100,
                                 type: 'square'
@@ -183,7 +182,7 @@ $('#item').croppie(method, args);</code></pre>
                                 <li><code class="language-javascript">url</code> URL to image</li>
                                 <li><code class="language-javascript">points</code> Array of points that translate into <code class="language-javascript">[topLeftX, topLeftY, bottomRightX, bottomRightY]</code></li>
                                 <li><code class="language-javascript">zoom</code> Apply zoom after image has been bound </li>
-                                <li><code class="language-javascript">orientation</code> Custom orientation, applied after exif orientation (if enabled). Only works with 
+                                <li><code class="language-javascript">orientation</code> Custom orientation, applied after exif orientation (if enabled). Only works with
                                     <code class="language-javascript">enableOrientation</code> option enabled (see 'Options').
                                     <br />
                                     Valid options are:
@@ -226,7 +225,7 @@ $('#item').croppie(method, args);</code></pre>
                                     <code class="language-javascript">'rawcanvas'</code> returns the canvas element allowing you to manipulate prior to getting the resulted image
                                 </li>
                                 <li>
-                                    <code class="language-javascript">size</code> The size of the cropped image defaults to <code class="language-javascript">'viewport'</code> 
+                                    <code class="language-javascript">size</code> The size of the cropped image defaults to <code class="language-javascript">'viewport'</code>
                                 </li>
                                 <li class="values">
                                     <code class="language-javascript">'viewport'</code> the size of the resulting image will be the same width and height as the viewport
@@ -472,7 +471,7 @@ $('#hidden-demo').croppie('bind')</code></pre>
                     <p>Croppie is dependent on it's container being visible when the <a href="#bind">bind</a> method is called.  This can be an issue when your croppie component is inside a modal that isn't shown. Let's take the bootstrap modal for example..</p>
                     <pre class="language-javascript"><code class="language-javascript">
 var myCroppie = $('#my-croppie').croppie(opts);
-$('#my-modal').on('shown.bs.modal', function(){ 
+$('#my-modal').on('shown.bs.modal', function(){
     myCroppie.croppie('bind', bindOpts);
 });
                     </code></pre>
@@ -523,7 +522,7 @@ $('#my-modal').on('shown.bs.modal', function(){
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
         <script>window.jQuery || document.write('<script src="bower_components/jquery/dist/jquery.min.js"><\/script>')</script>
         <script src="demo/prism.js"></script>
-        <script src="bower_components/sweetalert/dist/sweetalert.min.js"></script>
+        <script src="bower_components/sweetalert2/dist/sweetalert2.all.min.js"></script>
 
         <script src="croppie.js"></script>
         <script src="demo/demo.js"></script>


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2019, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

4. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
  
5. Fix horizontal jumpiness

![croppie](https://user-images.githubusercontent.com/6059356/51737316-e920cb80-2094-11e9-89f3-394061d06fa1.gif)

6. Less LOC

---

PS. my editor automatically got rid of all trailing whitespaces