### PR TITLE
default zoom does not show the whole picture

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1091,7 +1091,7 @@
             _setZoomerVal.call(self, scale < zoomer.min ? zoomer.min : zoomer.max);
         }
         else if (initial) {
-            defaultInitialZoom = Math.max((boundaryData.width / imgData.width), (boundaryData.height / imgData.height));
+            defaultInitialZoom = Math.min((boundaryData.width / imgData.width), (boundaryData.height / imgData.height)); //Math.max in Math.min ge\E4ndert
             initialZoom = self.data.boundZoom !== null ? self.data.boundZoom : defaultInitialZoom;
             _setZoomerVal.call(self, initialZoom);
         }


### PR DESCRIPTION
This bugfix should prevent an image to be zoomed to maximize one axis.
If the image is too small, for the canvas element, this will show some borders around.
If this was by desire, I suggest having an option to decide which default zoom to use.