### PR TITLE
Rotate max

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -755,7 +755,7 @@
         };
     }
 
-    function _updateCenterPoint(rotate) {
+    function _updateCenterPoint() {
         var self = this,
             scale = self._currentZoom,
             data = self.elements.preview.getBoundingClientRect(),
@@ -767,7 +767,7 @@
             center = {},
             adj = {};
 
-        if (rotate) {
+        /*if (rotate) { //this does not work as expected, use centerImage instead
             var cx = pc.x;
             var cy = pc.y;
             var tx = transform.x;
@@ -778,7 +778,7 @@
             transform.y = tx;
             transform.x = ty;
         }
-        else {
+        else {*/
             center.y = top / scale;
             center.x = left / scale;
 
@@ -787,7 +787,7 @@
 
             transform.x -= adj.x;
             transform.y -= adj.y;
-        }
+        //}
 
         var newCss = {};
         newCss[CSS_TRANS_ORG] = center.x + 'px ' + center.y + 'px';
@@ -1127,15 +1127,27 @@
         self._currentZoom = scale;
     }
 
-    function _centerImage() {
+    function _centerImage(rotate) {
         var self = this,
             imgDim = self.elements.preview.getBoundingClientRect(),
             vpDim = self.elements.viewport.getBoundingClientRect(),
             boundDim = self.elements.boundary.getBoundingClientRect(),
-            vpLeft = vpDim.left - boundDim.left,
-            vpTop = vpDim.top - boundDim.top,
-            w = vpLeft - ((imgDim.width - vpDim.width) / 2),
-            h = vpTop - ((imgDim.height - vpDim.height) / 2),
+            vpLeft,
+            vpTop,
+            w,
+            h,
+            transform;
+
+      if(rotate){//in case of rotation reset earlier transformations, so this calculation is not added on top
+        var newCss = {};
+        newCss[CSS_TRANS_ORG] = 0 + 'px ' + 0 + 'px';
+        css(self.elements.preview, newCss);
+      }
+
+      vpLeft = vpDim.left - boundDim.left;
+      vpTop = vpDim.top - boundDim.top;
+      w = vpLeft - ((imgDim.width - vpDim.width) / 2);
+      h = vpTop - ((imgDim.height - vpDim.height) / 2);
             transform = new Transform(w, h, self._currentZoom);
 
         css(self.elements.preview, CSS_TRANSFORM, transform.toString());
@@ -1471,8 +1483,9 @@
 
         self.data.orientation = getExifOffset(self.data.orientation, deg);
         drawCanvas(canvas, self.elements.img, self.data.orientation);
-        _updateCenterPoint.call(self, true);
+        _updateCenterPoint.call(self);
         _updateZoomLimits.call(self);
+        _centerImage.call(self, true);
 
         // Reverses image dimensions if the degrees of rotation is not divisible by 180.
         if ((Math.abs(deg) / 90) % 2 === 1) {

--- a/croppie.js
+++ b/croppie.js
@@ -1091,7 +1091,7 @@
             _setZoomerVal.call(self, scale < zoomer.min ? zoomer.min : zoomer.max);
         }
         else if (initial) {
-            defaultInitialZoom = Math.max((boundaryData.width / imgData.width), (boundaryData.height / imgData.height));
+            defaultInitialZoom = Math.min((boundaryData.width / imgData.width), (boundaryData.height / imgData.height)); //Math.max in Math.min ge\E4ndert
             initialZoom = self.data.boundZoom !== null ? self.data.boundZoom : defaultInitialZoom;
             _setZoomerVal.call(self, initialZoom);
         }

--- a/index.html
+++ b/index.html
@@ -261,11 +261,14 @@ $('#item').croppie(method, args);</code></pre>
                             </ul>
                         </li>
                         <li id="rotate">
-                            <strong class="focus">rotate(degrees)</strong><em></em>
+                            <strong class="focus">rotate(degrees, maximize)</strong><em></em>
                             <p>Rotate the image by a specified degree amount.  Only works with <code class="language-javascript">enableOrientation</code> option enabled (see 'Options').</p>
                             <ul class="parameter-list">
                                 <li>
                                     <code class="language-javascript">degrees</code> <span class="default">Valid Values:</span><code>90, 180, 270, -90, -180, -270</code>
+                                </li>
+                                <li>
+                                    <code class="language-javascript">maximize</code> set to true if the image should be maximised inside the canvas element after the rotation.
                                 </li>
                             </ul>
                         </li>


### PR DESCRIPTION
If the image has an aspect of 16:9, like the canvas element, but the initial rotation was wrong. The element fills only the y-axis. So after rotation, you have to manually zoom the picture to get the full size of the canvas element. This is usually not what was wanted.
Added an optional parameter, so one can decide whether the want the maximization or not.