### PR TITLE
fix broken (not smooth) pixel when crop image

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -1225,6 +1225,14 @@
         }
 
         // console.table({ left, right, top, bottom, canvasWidth, canvasHeight, width, height, startX, startY, circle, sx, sy, dx, dy, sWidth, sHeight, dWidth, dHeight });
+		
+		// When the pixel from source position is directly transfered to the destination position, loosing all the neighbouring pixels information. The resulting image may often look very noisy.
+		// Set these properties is a simple area-average downsampling, producing preferable results with relatively small processing time.
+		ctx.mozImageSmoothingEnabled = true;
+		ctx.imageSmoothingQuality = "high";
+		ctx.webkitImageSmoothingEnabled = true;
+		ctx.msImageSmoothingEnabled = true;
+		ctx.imageSmoothingEnabled = true;
 
         ctx.drawImage(this.elements.preview, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
         if (circle) {


### PR DESCRIPTION
I add some code to resolve the broken or not smooth image problem when image is cropped.
You can see the change I have presented in example below:
https://jsfiddle.net/thanhld24/n7ja32qb/
Ps: please read the note what I commented in javascript frame in jsfiddle