### PR TITLE
Fix Bad Apostrophe

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,7 +469,7 @@ $('#hidden-demo').croppie('bind')</code></pre>
                 <article>
                     <a id="visibility" name="visibility"></a>
                     <h3>Visibility and Binding</h3>
-                    <p>Croppie is dependent on it's container being visible when the <a href="#bind">bind</a> method is called.  This can be an issue when your croppie component is inside a modal that isn't shown. Let's take the bootstrap modal for example..</p>
+                    <p>Croppie is dependent on its container being visible when the <a href="#bind">bind</a> method is called.  This can be an issue when your croppie component is inside a modal that isn't shown. Let's take the bootstrap modal for example..</p>
                     <pre class="language-javascript"><code class="language-javascript">
 var myCroppie = $('#my-croppie').croppie(opts);
 $('#my-modal').on('shown.bs.modal', function(){ 


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!